### PR TITLE
Moved torso pitch setting to "torso" dictionary of robot config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Moved torso pitch setting to "torso" dictionary of robot config
 - Switch license to BSD 2-clause for compatibility with other mc\_rtc projects
 - Updated dependencies
 

--- a/etc/LIPMWalking.conf.cmake
+++ b/etc/LIPMWalking.conf.cmake
@@ -194,7 +194,6 @@
         "name": "WAIST_R_S",
         "pitch": 0.0
       }
->>>>>>> Stashed changes
     }
   },
   "plans":
@@ -739,6 +738,31 @@
           { "pose": { "translation": [1.0, -0.105, 0.0] }, "ref_vel": [0.0, 0.0, 0.0], "surface": "RightFootCenter" },
           { "pose": { "translation": [1.0,  0.105, 0.0] }, "ref_vel": [0.0, 0.0, 0.0], "surface": "LeftFootCenter" }
         ]
+      },
+      "step_40cm_forward":
+      {
+        "init_dsp_duration": 0.6,
+        "double_support_duration": 0.1,
+        "single_support_duration": 0.7,
+        "final_dsp_duration": 0.6,
+        "swing_height": 0.04,
+        "torso_pitch": 0.0,
+        "contacts":
+        [
+          { "pose": { "translation": [0.0, -0.105, 0.0] }, "ref_vel": [0.0,  0.0, 0.0], "surface": "RightFootCenter" },
+          { "pose": { "translation": [0.0,  0.105, 0.0] }, "ref_vel": [0.1,  0.0, 0.0], "surface": "LeftFootCenter"  },
+          { "pose": { "translation": [0.4, -0.105, 0.0] }, "ref_vel": [0.1,  0.0, 0.0], "surface": "RightFootCenter" },
+          { "pose": { "translation": [0.4,  0.105, 0.0] }, "ref_vel": [0.0,  0.0, 0.0], "surface": "LeftFootCenter"  }
+        ],
+        "mpc":
+        {
+          "weights":
+          {
+            "jerk": 1.0,
+            "vel": [100.0, 100.0],
+            "zmp": 1000.0
+          }
+        }
       },
       "warmup":
       {

--- a/etc/LIPMWalking.conf.cmake
+++ b/etc/LIPMWalking.conf.cmake
@@ -60,7 +60,6 @@
     },
     "torso":
     {
-      "pitch": 0.1,
       "stiffness": 10.0,
       "weight": 100.0
     }
@@ -104,7 +103,11 @@
         "half_width": 0.065,
         "friction": 0.7
       },
-      "torso": "torso"
+      "torso":
+      {
+        "name": "torso",
+        "pitch": 0.1
+      }
     },
     "hrp2_drc":
     {
@@ -143,7 +146,55 @@
         "half_width": 0.07,
         "friction": 0.7
       },
-      "torso": "CHEST_LINK1"
+      "torso":
+      {
+        "name": "CHEST_LINK1",
+        "pitch": 0.0
+      }
+    },
+    "jvrc1":
+    {
+      "admittance":
+      {
+        "com": [0.0, 0.0],
+        "cop": [0.01, 0.01],
+        "dfz": 0.0001,
+        "dfz_damping": 0.0
+      },
+      "com":
+      {
+        "active_joints": [
+          "Root",
+          "R_HIP_Y", "R_HIP_R", "R_HIP_P", "R_KNEE_P", "R_ANKLE_P", "R_ANKLE_R",
+          "L_HIP_Y", "L_HIP_R", "L_HIP_P", "L_KNEE_P", "L_ANKLE_P", "L_ANKLE_R"
+        ],
+        "height": 0.88,
+        "max_height": 0.95,
+        "min_height": 0.65
+      },
+      "dcm_tracking":
+      {
+        "gains":
+        {
+          "prop": 5.0,
+          "integral": 10.0,
+          "deriv": 0.0
+        },
+        "derivator_time_constant": 1.0,
+        "integrator_time_constant": 10.0
+      },
+      "sole":
+      {
+        "half_length": 0.112,
+        "half_width": 0.065,
+        "friction": 0.7
+      },
+      "torso":
+      {
+        "name": "WAIST_R_S",
+        "pitch": 0.0
+      }
+>>>>>>> Stashed changes
     }
   },
   "plans":

--- a/src/Controller.cpp
+++ b/src/Controller.cpp
@@ -72,10 +72,10 @@ namespace lipm_walking
     postureTask->stiffness(postureStiffness);
     postureTask->weight(postureWeight);
 
-    std::string torsoName = robotConfig("torso");
+    std::string torsoName = robotConfig("torso")("name");
+    robotConfig("torso")("pitch", defaultTorsoPitch_);
     double torsoStiffness = config("tasks")("torso")("stiffness");
     double torsoWeight = config("tasks")("torso")("weight");
-    config("tasks")("torso")("pitch", defaultTorsoPitch_);
     torsoPitch_ = defaultTorsoPitch_;
     torsoTask = std::make_shared<mc_tasks::OrientationTask>(torsoName, robots(), 0);
     torsoTask->orientation(mc_rbdyn::rpyToMat({0, torsoPitch_, 0}) * pelvisOrientation_);


### PR DESCRIPTION
Meanwhile, we update the torso pitch setting for HRP-2Kai to 0 [rad].
