### PR TITLE
[HRP5P] Initial gain tuning on real HRP5P

### DIFF
--- a/etc/LIPMWalking.in.yaml
+++ b/etc/LIPMWalking.in.yaml
@@ -93,7 +93,7 @@ robot_models:
   hrp5_p:
     admittance:
       com: [0.0, 0.0]
-      cop: [0.001, 0.001]
+      cop: [0.008, 0.008]
       dfz: 0.0001
       dfz_damping: 0.0
     com:
@@ -103,7 +103,7 @@ robot_models:
       min_height: 0.6
     dcm_tracking:
       gains:
-        prop: 2.0
+        prop: 4.0
         integral: 10.0
         deriv: 0.5
       derivator_time_constant: 5.0

--- a/etc/LIPMWalking.in.yaml
+++ b/etc/LIPMWalking.in.yaml
@@ -93,7 +93,7 @@ robot_models:
   hrp5_p:
     admittance:
       com: [0.0, 0.0]
-      cop: [0.01, 0.01]
+      cop: [0.001, 0.001]
       dfz: 0.0001
       dfz_damping: 0.0
     com:
@@ -103,9 +103,9 @@ robot_models:
       min_height: 0.6
     dcm_tracking:
       gains:
-        prop: 10.0
+        prop: 2.0
         integral: 10.0
-        deriv: 2.0
+        deriv: 0.5
       derivator_time_constant: 5.0
       integrator_time_constant: 15.0
     sole:

--- a/include/lipm_walking/Stabilizer.h
+++ b/include/lipm_walking/Stabilizer.h
@@ -70,9 +70,9 @@ struct Stabilizer
   static constexpr double MAX_DFZ_DAMPING =
       10.; /**< Maximum normalized damping in [Hz] for foot force difference control */
   static constexpr double MAX_FDC_RX_VEL =
-      0.2; /**< Maximum x-axis angular velocity in [rad] / [s] for foot damping control. */
+      0.8; /**< Maximum x-axis angular velocity in [rad] / [s] for foot damping control. */
   static constexpr double MAX_FDC_RY_VEL =
-      0.2; /**< Maximum y-axis angular velocity in [rad] / [s] for foot damping control. */
+      0.8; /**< Maximum y-axis angular velocity in [rad] / [s] for foot damping control. */
   static constexpr double MAX_FDC_RZ_VEL =
       0.2; /**< Maximum z-axis angular velocity in [rad] / [s] for foot damping control. */
   static constexpr double MAX_ZMPCC_COM_OFFSET = 0.05; /**< Maximum CoM offset due to admittance control in [m] */


### PR DESCRIPTION
Gain tuning with @mehdi-benallegue. Tested with walking up with up to 30cm steps, including turning, turning in place, lateral stepping etc. The gains could probably be further increased if necessary. Also tested while walking with a heavy bobbin.

Note: We noticed an offset of about `[0.01, 0.0, 0.0]` of the DCM, that we compensated for manually. @mehdi-benallegue is working on an estimator for automatically observing it.